### PR TITLE
fix: Migrated manifest V2 to V3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,12 +1,12 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "DWR Explorer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "icons": {
     "200": "assets/dwr-logo.png"
   },
   "devtools_page": "devtools.html",
-  "permissions": [
+  "host_permissions": [
     "http://*/*",
     "https://*/*"
   ],
@@ -14,6 +14,14 @@
      "pages": ["sandbox.html"]
   },
   "web_accessible_resources": [
-    "assets/*"
+    {
+      "resources": [
+         "assets/*"
+      ],
+      "matches": [
+        "*://*/*"
+      ]
+    }
+   
   ]
 }


### PR DESCRIPTION
chrome extension manifest v2 is deprecated and is being phased out 
https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline
chrome extension paging is asking user to remove the extention

I have upgraded manifest to v3 using migration guide
https://developer.chrome.com/docs/extensions/develop/migrate

